### PR TITLE
fix: set make_latest explicitly to prevent ghost releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Calculate new version
         if: steps.bump_type.outputs.bump != 'none'
         id: new_version
+        working-directory: ${{ github.event.repository.name }}
         run: |
           LATEST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
           LATEST_TAG="${LATEST_TAG:-0.0.0}"
@@ -55,6 +56,7 @@ jobs:
         with:
           tag_name: ${{ steps.new_version.outputs.version }}
           generate_release_notes: true
+          make_latest: true
 
       ### DEFAULT GALAXY IMPORT (uses GitHub owner as namespace)
       # - name: Import role to Ansible Galaxy


### PR DESCRIPTION
Race condition in softprops/action-gh-release can leave a release
visible via API but not on the web UI. Explicit make_latest: true
ensures proper propagation.
